### PR TITLE
Fixed a compiling issue related to future use of Erlang 27.

### DIFF
--- a/plugins_src/scripting/Makefile
+++ b/plugins_src/scripting/Makefile
@@ -35,8 +35,8 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.beam)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror -I $(WINGS_TOP) $(TYPE_FLAGS) -pa $(WINGS_INTL) +debug_info
-
+ERL_COMPILE_FLAGS += -Werror +nowarn_match_float_zero -I $(WINGS_TOP) \
+	$(TYPE_FLAGS) -pa $(WINGS_INTL) +debug_info
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------


### PR DESCRIPTION
By building this branch I was getting lots of this warning:
> matching on the float 0.0 will no longer also match -0.0 in OTP 27.
> If you specifically intend to match 0.0 alone, write +0.0 instead.

Then, rebasing it to the main repository (**dgud**) fixed most of them, but then it stopped in your code. This change fix that.